### PR TITLE
use a Harmony finalizer for rebuilding menus

### DIFF
--- a/ConfigurableBuildMenus/ConfigurableBuildMenus_Patches.cs
+++ b/ConfigurableBuildMenus/ConfigurableBuildMenus_Patches.cs
@@ -11,7 +11,7 @@ namespace ConfigurableBuildMenus
         [HarmonyPatch(nameof(GeneratedBuildings.LoadGeneratedBuildings))]
         public class GeneratedBuildings_LoadGeneratedBuildings_Patch
         {
-            public static void Postfix()
+            public static void Finalizer()
             {
                 JsonSerializer<ExistingBuildingIDs>.Serialize(new ExistingBuildingIDs());
 


### PR DESCRIPTION
Some mods use GeneratedBuildings.LoadGeneratedBuildings() to add their buildings, so such buildings would be seen only depending on mod load order. Finalizers are called only after postfixes.