### PR TITLE
allow to specify also building category

### DIFF
--- a/ConfigurableBuildMenus/Config.cs
+++ b/ConfigurableBuildMenus/Config.cs
@@ -53,6 +53,7 @@ namespace ConfigurableBuildMenus
                 {
                     BuildingId = "required. Must match Id of an existing building you want to customize.",
                     MoveToMenu = "Id of the menu you want to move your building to (by default on the end of the list). Optional - if not provided, the building will be removed",
+                    Category = "Id of a building category. Buildings are grouped by category in each menu. Optional, original category or 'uncategorized' used if not provided",
                     JustAfter = "Id of a building. Your building will be placed just after the specified one. Optional.",
                     OnListBeginning = "if set to true, your building will be placed on the very beginning of the menu, ignoring JustAfter value. Optional. In case many buildings have this, all of them will end up on the beginning of the menu and the last building in the config will be first in the menu."
                 }
@@ -133,6 +134,7 @@ namespace ConfigurableBuildMenus
             {
                 public string BuildingId;
                 public string MoveToMenu;
+                public string Category;
                 public string JustAfter;
                 public string OnListBeginning;
             }
@@ -152,6 +154,7 @@ namespace ConfigurableBuildMenus
         {
             public string BuildingId;
             public string MoveToMenu;
+            public string Category;
             public string JustAfter;
             public bool OnListBeginning;
         }

--- a/ConfigurableBuildMenus/PlanorderHelper.cs
+++ b/ConfigurableBuildMenus/PlanorderHelper.cs
@@ -109,6 +109,20 @@ namespace ConfigurableBuildMenus
                 Debug.Log($"{ModInfo.Namespace}: Could not find building {movedItem.BuildingId}");
                 return;
             }
+            // If an existing modded building is removed and added elsewhere, remember its subcategory,
+            // unless explicitly given.
+            if(string.IsNullOrEmpty(movedItem.Category))
+            {
+                var planOrderData = BUILDINGS.PLANORDER[oldCategory];
+                foreach (KeyValuePair<string, string> datum in planOrderData.buildingAndSubcategoryData)
+                {
+                    if (datum.Key == movedItem.BuildingId)
+                    {
+                        movedItem.Category = datum.Value;
+                        break;
+                    }
+                }
+            }
             BUILDINGS.PLANORDER[oldCategory].data.RemoveAll(x => x == movedItem.BuildingId);
             BUILDINGS.PLANORDER[oldCategory].buildingAndSubcategoryData.RemoveAll(x => x.Key == movedItem.BuildingId);
         }
@@ -131,6 +145,9 @@ namespace ConfigurableBuildMenus
             string category = "uncategorized"; 
             if(BUILDINGS.PLANSUBCATEGORYSORTING.ContainsKey(movedItem.BuildingId))
                 category = BUILDINGS.PLANSUBCATEGORYSORTING[movedItem.BuildingId];
+            if(!string.IsNullOrEmpty(movedItem.Category))
+                category = movedItem.Category;
+
             KeyValuePair<string, string> movedPair = new KeyValuePair<string, string>(movedItem.BuildingId, category);
 
             if (movedItem.OnListBeginning)


### PR DESCRIPTION
ONI (since some time later than this mod was started?) first groups buildings in the menu by category and only keeps order within each group. In order to be able to move a building to a specific position in a menu, it may be necessary to specify a category too (especially with some modded buildings that do not specify their category, get the default 'uncategorized' and end up first in the menu).

This commit allows to explicitly specify a category, otherwise it keeps the existing category (if specified, was buggy with modded buildings).