### PR TITLE
FragrantFlowers - Duskbloom recipe change to antihistamine

### DIFF
--- a/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
+++ b/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
@@ -68,17 +68,17 @@ namespace FragrantFlowers
         {
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
-                new ComplexRecipe.RecipeElement(SimHashes.Water.CreateTag(), 100f),
-                new ComplexRecipe.RecipeElement(ID, 1f)
+                new ComplexRecipe.RecipeElement(ID, 1f),
+                new ComplexRecipe.RecipeElement(SimHashes.Dirt.CreateTag(), 1f),
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {
-                new ComplexRecipe.RecipeElement(BasicCureConfig.ID, 1f, ComplexRecipe.RecipeElement.TemperatureOperation.AverageTemperature)
+                new ComplexRecipe.RecipeElement(AntihistamineConfig.ID, 1f, ComplexRecipe.RecipeElement.TemperatureOperation.AverageTemperature)
             };
             ComplexRecipe recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(ApothecaryConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {
                 time = 100f,
-                description = ITEMS.PILLS.BASICCURE.RECIPEDESC,
+                description = ITEMS.PILLS.ANTIHISTAMINE.RECIPEDESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { ApothecaryConfig.ID },
                 sortOrder = 10


### PR DESCRIPTION
Hi! I suggest to change Duskbloom medicine from basic pill to antihistamine because you cant make any on astroids like Frozen Forest. So allergy become a real problem.