### PR TITLE
DiseasesExpanded - Cures QoL fixes

### DIFF
--- a/DiseasesExpanded/Cures/AlienSicknessCureConfig.cs
+++ b/DiseasesExpanded/Cures/AlienSicknessCureConfig.cs
@@ -56,11 +56,12 @@ namespace DiseasesExpanded
             };
             recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(ApothecaryConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {
-                time = 100f,
+                time = 200f,
                 description = STRINGS.CURES.ALIENCURE.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)ApothecaryConfig.ID },
-                sortOrder = 11
+                sortOrder = 20,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/AllergyVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/AllergyVaccineConfig.cs
@@ -43,7 +43,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)VaccineApothecaryConfig.GetAdvancedApothecaryId() },
-                sortOrder = 41
+                sortOrder = 41,
+                requiredTech = "MedicineIV"
             };
 
             MedicineInfo info = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.Booster, null, null);

--- a/DiseasesExpanded/Cures/GasCureConfig.cs
+++ b/DiseasesExpanded/Cures/GasCureConfig.cs
@@ -37,8 +37,8 @@ namespace DiseasesExpanded
 
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
+                new ComplexRecipe.RecipeElement((Tag) PrickleFlowerConfig.SEED_ID, 1f),
                 new ComplexRecipe.RecipeElement(SimHashes.Fertilizer.CreateTag(), 1f),
-                new ComplexRecipe.RecipeElement((Tag) PrickleFlowerConfig.SEED_ID, 1f)
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {
@@ -50,7 +50,7 @@ namespace DiseasesExpanded
                 description = STRINGS.CURES.GASCURE.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)ApothecaryConfig.ID },
-                sortOrder = 11
+                sortOrder = 12
             };
         }
     }

--- a/DiseasesExpanded/Cures/GassyVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/GassyVaccineConfig.cs
@@ -56,7 +56,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)VaccineApothecaryConfig.GetAdvancedApothecaryId() },
-                sortOrder = 44
+                sortOrder = 44,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/HappyPillConfig.cs
+++ b/DiseasesExpanded/Cures/HappyPillConfig.cs
@@ -15,7 +15,7 @@ namespace DiseasesExpanded
 
         public static Effect GetEffect()
         {
-            Effect effect = new Effect(EFFECT_ID, "Happy Pill Effect", "Happy Pill Desc", 600, true, true, false);
+            Effect effect = new Effect(EFFECT_ID, STRINGS.CURES.HAPPYPILL.NAME, STRINGS.CURES.HAPPYPILL.DESC, 600, true, true, false);
             effect.SelfModifiers = new List<AttributeModifier>();
             effect.SelfModifiers.Add(new AttributeModifier("StressDelta", stressPerSecond, EFFECT_ID));
             effect.SelfModifiers.Add(new AttributeModifier("QualityOfLife", moraleBonus, EFFECT_ID));
@@ -60,7 +60,7 @@ namespace DiseasesExpanded
                 description = STRINGS.CURES.HAPPYPILL.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)ApothecaryConfig.ID },
-                sortOrder = 11
+                sortOrder = 12
             };
 
             MedicineInfo info = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.Booster, (string)null);

--- a/DiseasesExpanded/Cures/HungermsVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/HungermsVaccineConfig.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace DiseasesExpanded
 {
-    class HungermsVaccineConfig// : IEntityConfig
+    class HungermsVaccineConfig : IEntityConfig
     {
         public const string ID = "HungermsVaccine";
         public const string EffectID = "HungermsVaccineEffect";

--- a/DiseasesExpanded/Cures/HungermsVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/HungermsVaccineConfig.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace DiseasesExpanded
 {
-    class HungermsVaccineConfig : IEntityConfig
+    class HungermsVaccineConfig// : IEntityConfig
     {
         public const string ID = "HungermsVaccine";
         public const string EffectID = "HungermsVaccineEffect";
@@ -44,7 +44,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)VaccineApothecaryConfig.GetAdvancedApothecaryId() },
-                sortOrder = 1
+                sortOrder = 41,
+                requiredTech = "MedicineIV"
             };
             */
 

--- a/DiseasesExpanded/Cures/MudMaskConfig.cs
+++ b/DiseasesExpanded/Cures/MudMaskConfig.cs
@@ -47,7 +47,7 @@ namespace DiseasesExpanded
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {
-                new ComplexRecipe.RecipeElement((Tag) ID, 10f, ComplexRecipe.RecipeElement.TemperatureOperation.AverageTemperature)
+                new ComplexRecipe.RecipeElement((Tag) ID, 1f, ComplexRecipe.RecipeElement.TemperatureOperation.AverageTemperature)
             };
             MudMaskConfig.recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(ApothecaryConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {

--- a/DiseasesExpanded/Cures/MutatingAntiviralConfig.cs
+++ b/DiseasesExpanded/Cures/MutatingAntiviralConfig.cs
@@ -40,22 +40,22 @@ namespace DiseasesExpanded
         {
             DefineRecipe(BasicForagePlantConfig.ID, 2);
             DefineRecipe(ForestForagePlantConfig.ID, 0.25f);
-            if(DlcManager.IsExpansion1Active())
+            if (DlcManager.IsExpansion1Active())
                 DefineRecipe(SwampForagePlantConfig.ID, 2 / 3.0f);
 
             MedicineInfo medInfo = new MedicineInfo(ID, EffectID, MedicineInfo.MedicineType.CureSpecific, null, new string[] { MutatingSickness.ID });
 
-            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, 
-                STRINGS.CURES.MUTATINGANTIVIRAL.NAME, 
-                STRINGS.CURES.MUTATINGANTIVIRAL.NAME, 
+            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID,
+                STRINGS.CURES.MUTATINGANTIVIRAL.NAME,
+                STRINGS.CURES.MUTATINGANTIVIRAL.DESC,
                 1f,
-                false, 
-                Assets.GetAnim(Kanims.UnstableAntiviralKanim), 
-                "object", 
-                Grid.SceneLayer.Front, 
-                EntityTemplates.CollisionShape.RECTANGLE, 
-                0.8f, 
-                0.4f, 
+                true,
+                Assets.GetAnim(Kanims.UnstableAntiviralKanim),
+                "object",
+                Grid.SceneLayer.Front,
+                EntityTemplates.CollisionShape.RECTANGLE,
+                0.8f,
+                0.4f,
                 true);
 
             GameObject medicineEntity = EntityTemplates.ExtendEntityToMedicine(looseEntity, medInfo);

--- a/DiseasesExpanded/Cures/RadShotConfig.cs
+++ b/DiseasesExpanded/Cures/RadShotConfig.cs
@@ -17,7 +17,7 @@ namespace DiseasesExpanded
 
             MedicineInfo medInfo = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.CureSpecific, AdvancedDoctorStationConfig.ID, new string[] { HungerSickness.ID });
 
-            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.CURES.RADSHOT.NAME, STRINGS.CURES.RADSHOT.NAME, 1f, false, Assets.GetAnim(Kanims.RadShotKanim), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
+            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.CURES.RADSHOT.NAME, STRINGS.CURES.RADSHOT.DESC, 1f, true, Assets.GetAnim(Kanims.RadShotKanim), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
             GameObject medicineEntity = EntityTemplates.ExtendEntityToMedicine(looseEntity, medInfo);
             return medicineEntity;
         }
@@ -39,11 +39,12 @@ namespace DiseasesExpanded
             };
             recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(ApothecaryConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {
-                time = 100f,
+                time = 200f,
                 description = STRINGS.CURES.RADSHOT.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { ApothecaryConfig.ID },
-                sortOrder = 12
+                sortOrder = 20,
+                requiredTech = "MedicineIV"
             };
         }
 

--- a/DiseasesExpanded/Cures/SapShotConfig.cs
+++ b/DiseasesExpanded/Cures/SapShotConfig.cs
@@ -18,7 +18,7 @@ namespace DiseasesExpanded
 
             MedicineInfo medInfo = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.CureSpecific, AdvancedDoctorStationConfig.ID, new string[] { HungerSickness.ID });
 
-            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.CURES.SAPSHOT.NAME, STRINGS.CURES.SAPSHOT.DESC, 1f, false, Assets.GetAnim(Kanims.SapShotKanim), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
+            GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.CURES.SAPSHOT.NAME, STRINGS.CURES.SAPSHOT.DESC, 1f, true, Assets.GetAnim(Kanims.SapShotKanim), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
             GameObject medicineEntity = EntityTemplates.ExtendEntityToMedicine(looseEntity, medInfo);
             return medicineEntity;
         }
@@ -40,11 +40,12 @@ namespace DiseasesExpanded
             };
             recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(ApothecaryConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {
-                time = 100f,
+                time = 200f,
                 description = STRINGS.CURES.SAPSHOT.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { ApothecaryConfig.ID },
-                sortOrder = 12
+                sortOrder = 20,
+                requiredTech = "MedicineIV"
             };
         }
 

--- a/DiseasesExpanded/Cures/SerumDeepBreathConfig.cs
+++ b/DiseasesExpanded/Cures/SerumDeepBreathConfig.cs
@@ -46,7 +46,7 @@ namespace DiseasesExpanded
         private void DefineRecipe()
         {
             if (!Settings.Instance.FrostPox.IncludeDisease)
-                return; 
+                return;
 
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[3]
             {
@@ -64,7 +64,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { VaccineApothecaryConfig.ID },
-                sortOrder = 1
+                sortOrder = 1,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/SerumSuperConfig.cs
+++ b/DiseasesExpanded/Cures/SerumSuperConfig.cs
@@ -74,7 +74,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { VaccineApothecaryConfig.ID },
-                sortOrder = 1
+                sortOrder = 1,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/SerumTummyConfig.cs
+++ b/DiseasesExpanded/Cures/SerumTummyConfig.cs
@@ -64,7 +64,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { VaccineApothecaryConfig.ID },
-                sortOrder = 1
+                sortOrder = 1,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/SerumYummyConfig.cs
+++ b/DiseasesExpanded/Cures/SerumYummyConfig.cs
@@ -65,7 +65,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { VaccineApothecaryConfig.ID },
-                sortOrder = 1
+                sortOrder = 1,
+                requiredTech = "MedicineIV"
             };
         }
     }

--- a/DiseasesExpanded/Cures/SlimelungVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/SlimelungVaccineConfig.cs
@@ -49,7 +49,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)VaccineApothecaryConfig.GetAdvancedApothecaryId() },
-                sortOrder = 42
+                sortOrder = 42,
+                requiredTech = "MedicineIV"
             };
 
             MedicineInfo info = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.Booster, null, null);

--- a/DiseasesExpanded/Cures/SunburnCureConfig.cs
+++ b/DiseasesExpanded/Cures/SunburnCureConfig.cs
@@ -37,7 +37,8 @@ namespace DiseasesExpanded
                 description = STRINGS.CURES.SUNBURNCURE.DESC,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)ApothecaryConfig.ID },
-                sortOrder = 10
+                sortOrder = 12,
+                requiredTech = "MedicineII"
             };
 
             MedicineInfo info = new MedicineInfo(ID, null, MedicineInfo.MedicineType.CureSpecific, DoctorStationConfig.ID, new string[] { Sunburn.ID });

--- a/DiseasesExpanded/Cures/ZombieSporesVaccineConfig.cs
+++ b/DiseasesExpanded/Cures/ZombieSporesVaccineConfig.cs
@@ -43,7 +43,8 @@ namespace DiseasesExpanded
                 description = Desc,
                 nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
                 fabricators = new List<Tag>() { (Tag)VaccineApothecaryConfig.GetAdvancedApothecaryId() },
-                sortOrder = 43
+                sortOrder = 43,
+                requiredTech = "MedicineIV"
             };
 
             MedicineInfo info = new MedicineInfo(ID, EFFECT_ID, MedicineInfo.MedicineType.Booster, null, null);

--- a/DiseasesExpanded/MedicalNanobots/NanobotUpgrade_StressReliefConfig.cs
+++ b/DiseasesExpanded/MedicalNanobots/NanobotUpgrade_StressReliefConfig.cs
@@ -45,6 +45,9 @@ namespace DiseasesExpanded
 
         private static void DefineRecipe()
         {
+            if (!Settings.Instance.MedicalNanobots.IncludeDisease)
+                return;
+
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
                 MedicalNanobotsData.MainIngridient,

--- a/DiseasesExpanded/Misc/MedicalResearchDataBank.cs
+++ b/DiseasesExpanded/Misc/MedicalResearchDataBank.cs
@@ -41,13 +41,13 @@ namespace DiseasesExpanded
 
                 if (techInstance.progressInventory.PointsByTypeID[MedicalResearchTypeId] == 0)
                 {
-                    if(tech.ArePrerequisitesComplete())
+                    if (tech.ArePrerequisitesComplete())
                         return techInstance;
 
                     bool firstMedTech = true;
                     bool previousMedTechCompleted = true;
 
-                    foreach(Tech previousTech in tech.requiredTech)
+                    foreach (Tech previousTech in tech.requiredTech)
                     {
                         if (previousTech.costsByResearchTypeID.ContainsKey(MedicalResearchTypeId))
                         {
@@ -102,6 +102,7 @@ namespace DiseasesExpanded
             Dictionary<string, float> FlaskEfficiency = new Dictionary<string, float>()
             {
                 { UnspecifiedFlask.ID, 1 },
+                { RadiationGermsFlask.ID, 1 },
                 { PollenFlask.ID, 1 },
                 { FoodGermsFlask.ID, 1 },
                 { SlimelungFlask.ID, 2 },
@@ -137,7 +138,7 @@ namespace DiseasesExpanded
 
         public GameObject CreatePrefab()
         {
-            if(Settings.Instance.EnableMedicalResearchPoints)
+            if (Settings.Instance.EnableMedicalResearchPoints)
                 DefineRecipes();
 
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(


### PR DESCRIPTION
Hi! It's just a bunch of small fixes for cures. Most of them are sort order change. 
Hungerms vaccine removed from Consumables tab.
Stress relief upgrade for nanobots now doesnt appear if nanobots are turned off.
I also added radiation flask to apothercary recipes, idk, it looks like you can get one from germcatcher.