### PR TITLE
FragrantFlowers - Plants and food rebalance experiment

### DIFF
--- a/FragrantFlowers/Food/DuskjamConfig.cs
+++ b/FragrantFlowers/Food/DuskjamConfig.cs
@@ -23,7 +23,7 @@ namespace FragrantFlowers
 
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
-                new ComplexRecipe.RecipeElement(Crop_DuskberryConfig.ID, 2f),
+                new ComplexRecipe.RecipeElement(Crop_DuskberryConfig.ID, 5/6.0f),
                 new ComplexRecipe.RecipeElement(SimHashes.Sucrose.CreateTag(), 4f)
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]

--- a/FragrantFlowers/Food/SpinosaCakeConfig.cs
+++ b/FragrantFlowers/Food/SpinosaCakeConfig.cs
@@ -40,7 +40,7 @@ namespace FragrantFlowers
                 sortOrder = 1
             };
 
-            EdiblesManager.FoodInfo info = new EdiblesManager.FoodInfo(ID, "EXPANSION1_ID", 4200000f, 5, 255.15f, 277.15f, 2400f, true); // see TUNING.FOOD.FOOD_TYPES.BERRY_PIE
+            EdiblesManager.FoodInfo info = new EdiblesManager.FoodInfo(ID, "EXPANSION1_ID", 6400000f, 5, 255.15f, 277.15f, 2400f, true); // see TUNING.FOOD.FOOD_TYPES.BERRY_PIE
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.FOOD.SPINOSACAKE.NAME, STRINGS.FOOD.SPINOSACAKE.DESC, 1f, true, Assets.GetAnim("food_rosecake_kanim"), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
             return EntityTemplates.ExtendEntityToFood(looseEntity, info);
         }

--- a/FragrantFlowers/Food/SpinosaSyrupConfig.cs
+++ b/FragrantFlowers/Food/SpinosaSyrupConfig.cs
@@ -23,9 +23,9 @@ namespace FragrantFlowers
 
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[3]
             {
-                new ComplexRecipe.RecipeElement(Crop_SpinosaHipsConfig.ID, 2f),
-                new ComplexRecipe.RecipeElement(SimHashes.Water.CreateTag(), 100f),
-                new ComplexRecipe.RecipeElement(SimHashes.Sucrose.CreateTag(), 2f)
+                new ComplexRecipe.RecipeElement(Crop_SpinosaHipsConfig.ID, 2/3.0f),
+                new ComplexRecipe.RecipeElement(SimHashes.Water.CreateTag(), 50f),
+                new ComplexRecipe.RecipeElement(SimHashes.Sucrose.CreateTag(), 4f)
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {

--- a/FragrantFlowers/Plants/Crop_CottonBollConfig.cs
+++ b/FragrantFlowers/Plants/Crop_CottonBollConfig.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using TUNING;
 using UnityEngine;
 using Database;
+using BUILDINGS = STRINGS.BUILDINGS;
 
 
 namespace FragrantFlowers
@@ -30,20 +31,20 @@ namespace FragrantFlowers
                 ID,
                 STRINGS.CROPS.COTTONBOLL.NAME,
                 STRINGS.CROPS.COTTONBOLL.DESC,
-                1f, 
-                false, 
-                Assets.GetAnim("item_cottonboll_kanim"), 
-                "object", 
-                Grid.SceneLayer.Front, 
-                EntityTemplates.CollisionShape.CIRCLE, 
-                0.35f, 
-                0.35f, 
-                true, 
-                0, 
-                SimHashes.Creature, 
+                1f,
+                true,
+                Assets.GetAnim("item_cottonboll_kanim"),
+                "object",
+                Grid.SceneLayer.Front,
+                EntityTemplates.CollisionShape.CIRCLE,
+                0.35f,
+                0.35f,
+                true,
+                0,
+                SimHashes.Creature,
                 new List<Tag>
                 {
-                    GameTags.CookingIngredient, 
+                    GameTags.CookingIngredient,
                     GameTags.IndustrialIngredient,
                     GameTags.BuildingFiber
                 });
@@ -51,11 +52,12 @@ namespace FragrantFlowers
             go.AddOrGet<SimpleMassStatusItem>();
 
             Rottable.Def def = go.AddOrGetDef<Rottable.Def>();
-            def.preserveTemperature = 255.15f;
-            def.rotTemperature = 277.15f;
-            def.spoilTime = 4800f;
+            def.preserveTemperature = 283.15f;
+            def.rotTemperature = 308.15f;
+            def.spoilTime = 9600f;
             def.staleTime = def.spoilTime / 2;
 
+            EntityTemplates.CreateAndRegisterCompostableFromPrefab(go);
             RegisterRecipe();
 
             return go;
@@ -82,9 +84,11 @@ namespace FragrantFlowers
             };
             recipe = new ComplexRecipe(ComplexRecipeManager.MakeRecipeID(RockCrusherConfig.ID, (IList<ComplexRecipe.RecipeElement>)ingredients, (IList<ComplexRecipe.RecipeElement>)results), ingredients, results)
             {
-                time = 100f,
-                description = ITEMS.INDUSTRIAL_PRODUCTS.BASIC_FABRIC.DESC,
-                nameDisplay = ComplexRecipe.RecipeNameDisplay.Result,
+                time = 20f,
+                description = string.Format(BUILDINGS.PREFABS.ROCKCRUSHER.RECIPE_DESCRIPTION,
+                Assets.GetPrefab(ID).GetProperName(),
+                Assets.GetPrefab(BasicFabricConfig.ID).GetProperName()),
+                nameDisplay = ComplexRecipe.RecipeNameDisplay.IngredientToResult,
                 fabricators = new List<Tag>() { RockCrusherConfig.ID },
                 sortOrder = 11
             };

--- a/FragrantFlowers/Plants/Crop_DuskberryConfig.cs
+++ b/FragrantFlowers/Plants/Crop_DuskberryConfig.cs
@@ -15,7 +15,7 @@ namespace FragrantFlowers
         }
 
         public const string ID = "Duskberry";
-        public const float GROW_TIME = 4500f;
+        public const float GROW_TIME = 6000f;
 
 
         public GameObject CreatePrefab()
@@ -38,14 +38,7 @@ namespace FragrantFlowers
                 null);
 
             EdiblesManager.FoodInfo foodInfo = new EdiblesManager.FoodInfo(
-                ID,
-                "",
-                1200000f,
-                -1,
-                255.15f,
-                277.15f,
-                3200f,
-                true);
+                ID, "", 2400000f, -1, 255.15f, 277.15f, 4800f, true);
 
             ExpandBerrySludgeRecipe();
 
@@ -66,7 +59,7 @@ namespace FragrantFlowers
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
                 new ComplexRecipe.RecipeElement((Tag) ColdWheatConfig.SEED_ID, 5f),
-                new ComplexRecipe.RecipeElement((Tag) ID, 1.333f)
+                new ComplexRecipe.RecipeElement((Tag) ID, 2/3.0f)
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {

--- a/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
+++ b/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
@@ -18,7 +18,7 @@ namespace FragrantFlowers
         public const string ID = "Duskbloom";
         public const string SPICE_ID = "DuskbloomSpice";
         public const string SPICE_SPRITE = "lavenderSpice_125";
-        public const float GROW_TIME = 4500f;
+        public const float GROW_TIME = Crop_DuskberryConfig.GROW_TIME / 2;
         public static readonly Tag TAG = TagManager.Create(ID);
 
         public GameObject CreatePrefab()
@@ -28,7 +28,7 @@ namespace FragrantFlowers
                 STRINGS.CROPS.DUSKBLOOM.NAME,
                 STRINGS.CROPS.DUSKBLOOM.DESC,
                 1f,
-                false,
+                true,
                 Assets.GetAnim("item_duskbloom_kanim"),
                 "object",
                 Grid.SceneLayer.Front,
@@ -38,9 +38,9 @@ namespace FragrantFlowers
                 true,
                 0,
                 SimHashes.Creature,
-                new List<Tag> { 
-                    GameTags.CookingIngredient, 
-                    GameTags.IndustrialIngredient 
+                new List<Tag> {
+                    GameTags.CookingIngredient,
+                    GameTags.IndustrialIngredient
                 });
             go.AddOrGet<EntitySplitter>();
             go.AddOrGet<SimpleMassStatusItem>();
@@ -50,6 +50,7 @@ namespace FragrantFlowers
             def.rotTemperature = 277.15f;
             def.spoilTime = 4800f;
             def.staleTime = def.spoilTime / 2;
+            EntityTemplates.CreateAndRegisterCompostableFromPrefab(go);
 
             DefineRecipe();
 

--- a/FragrantFlowers/Plants/Crop_SpinosaHipsConfig.cs
+++ b/FragrantFlowers/Plants/Crop_SpinosaHipsConfig.cs
@@ -15,36 +15,29 @@ namespace FragrantFlowers
         }
 
         public const string ID = "SpinosaHips";
-        public const float GROW_TIME = 4500f;
+        public const float GROW_TIME = 6000f;
 
         public GameObject CreatePrefab()
         {
             GameObject template = EntityTemplates.CreateLooseEntity(
-                ID, 
+                ID,
                 STRINGS.CROPS.SPINOSAHIPS.NAME,
                 STRINGS.CROPS.SPINOSAHIPS.DESC,
-                1f, 
-                false, 
-                Assets.GetAnim("fruit_spinosahips_kanim"), 
+                1f,
+                false,
+                Assets.GetAnim("fruit_spinosahips_kanim"),
                 "object",
-                Grid.SceneLayer.Front, 
-                EntityTemplates.CollisionShape.RECTANGLE, 
-                0.8f, 
-                0.4f, 
+                Grid.SceneLayer.Front,
+                EntityTemplates.CollisionShape.RECTANGLE,
+                0.8f,
+                0.4f,
                 true,
-                0, 
-                SimHashes.Creature, 
+                0,
+                SimHashes.Creature,
                 null);
 
             EdiblesManager.FoodInfo foodInfo = new EdiblesManager.FoodInfo(
-                ID, 
-                "", 
-                1200000f,
-                -1, 
-                255.15f, 
-                277.15f, 
-                3200f,
-                true);
+                ID, "", 2400000f, -1, 255.15f, 277.15f, 4800f, true);
 
             ExpandBerrySludgeRecipe();
 
@@ -65,7 +58,7 @@ namespace FragrantFlowers
             ComplexRecipe.RecipeElement[] ingredients = new ComplexRecipe.RecipeElement[2]
             {
                 new ComplexRecipe.RecipeElement((Tag) ColdWheatConfig.SEED_ID, 5f),
-                new ComplexRecipe.RecipeElement((Tag) ID, 1.333f)
+                new ComplexRecipe.RecipeElement((Tag) ID, 2/3.0f)
             };
             ComplexRecipe.RecipeElement[] results = new ComplexRecipe.RecipeElement[1]
             {

--- a/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
+++ b/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
@@ -18,29 +18,29 @@ namespace FragrantFlowers
         public const string ID = "SpinosaRose";
         public const string SPICE_ID = "SpinosaRoseSpice";
         public const string SPICE_SPRITE = "roseSpice_125";
-        public const float GROW_TIME = 4500f;
+        public const float GROW_TIME = Crop_SpinosaHipsConfig.GROW_TIME / 2;
         public static readonly Tag TAG = TagManager.Create(ID);
 
         public GameObject CreatePrefab()
         {
             GameObject go = EntityTemplates.CreateLooseEntity(
-                ID, 
+                ID,
                 STRINGS.CROPS.SPINOSAROSE.NAME,
-                STRINGS.CROPS.SPINOSAROSE.DESC, 
-                1f, 
-                false, 
-                Assets.GetAnim("item_spinosarose_kanim"), 
-                "object", 
-                Grid.SceneLayer.Front, 
-                EntityTemplates.CollisionShape.CIRCLE, 
-                0.35f, 
-                0.35f, 
-                true, 
-                0, 
-                SimHashes.Creature, 
-                new List<Tag>{ 
-                    GameTags.CookingIngredient, 
-                    GameTags.IndustrialIngredient 
+                STRINGS.CROPS.SPINOSAROSE.DESC,
+                1f,
+                true,
+                Assets.GetAnim("item_spinosarose_kanim"),
+                "object",
+                Grid.SceneLayer.Front,
+                EntityTemplates.CollisionShape.CIRCLE,
+                0.35f,
+                0.35f,
+                true,
+                0,
+                SimHashes.Creature,
+                new List<Tag> {
+                    GameTags.CookingIngredient,
+                    GameTags.IndustrialIngredient
                 });
             go.AddOrGet<EntitySplitter>();
             go.AddOrGet<SimpleMassStatusItem>();
@@ -50,6 +50,7 @@ namespace FragrantFlowers
             def.rotTemperature = 277.15f;
             def.spoilTime = 4800f;
             def.staleTime = def.spoilTime / 2;
+            EntityTemplates.CreateAndRegisterCompostableFromPrefab(go);
 
             DefineRecipe();
 

--- a/FragrantFlowers/Plants/Plant_DuskLavenderConfig.cs
+++ b/FragrantFlowers/Plants/Plant_DuskLavenderConfig.cs
@@ -34,12 +34,13 @@ namespace FragrantFlowers
 
         //===> TEMPERATURE SETTINGS <=====================================
         public const float DefaultTemperature = 299.15f;       //  26°C: Normal Temperature
-        public const float TemperatureLethalLow = 258.15f;     // -15ºC: Plant will die (Lowest Temp)
+        public const float TemperatureLethalLow = 243.15f;     // -30ºC: Plant will die (Lowest Temp)
         public const float TemperatureWarningLow = 288.15f;    //  15°C: Plant will stop growing (Lowest Temp)
         public const float TemperatureWarningHigh = 313.15f;   //  40°C: Plant will stop growing (Highest Temp)
         public const float TemperatureLethalHigh = 333.15f;    //  60°C: Plant will die (Highest Temp)
 
-        public const float Fertilization = 0.014f;         // Phosphorite Fertilization Needed
+        public const float Irrigation = 7 / 600.0f;             // Irrigation Needed
+        public const float Fertilization = 1 / 60.0f;         // Fertilization Needed
 
         public ComplexRecipe Recipe;
 
@@ -135,7 +136,7 @@ namespace FragrantFlowers
                 true, // Implies this Crop will grow old and eventualy yeilds a produce.
                 2400f, // Max age this Crop can grow, or the time it require for it to complete its growth.
                 0f, // Minium Radiation required by this Crop.
-                9800f, // Maxium value of Radiation this Crop can get before stop growing and dying.
+                TUNING.PLANTS.RADIATION_THRESHOLDS.TIER_5, // Maxium value of Radiation this Crop can get before stop growing and dying.
                 "LavenderOriginal", // Crop trait id.
                 "Lavender Original"); // Crop trait name.
 
@@ -144,14 +145,23 @@ namespace FragrantFlowers
             {
                 new PlantElementAbsorber.ConsumeInfo
                 {
-                    tag = SimHashes.Phosphorite.CreateTag(),
+                    tag = SimHashes.Dirt.CreateTag(),
                     massConsumptionRate = Fertilization
                 }
             });
-
+            //===> LIQUID IRRIGATION THIS CROP REQUIRES <===========================================================================
+            EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
+            {
+                new PlantElementAbsorber.ConsumeInfo
+                {
+                    tag = SimHashes.Water.CreateTag(),
+                    massConsumptionRate = Irrigation
+                }
+            });
             gameObject.AddOrGet<StandardCropPlant>();
             gameObject.AddOrGet<LoopingSounds>();
             gameObject.AddOrGet<BlightVulnerable>();
+            gameObject.AddOrGet<IlluminationVulnerable>().SetPrefersDarkness(true);
 
             //===> DISEASE OR GERMS THIS CROP RELEASES <===========================================================================
             DiseaseDropper.Def def = gameObject.AddOrGetDef<DiseaseDropper.Def>();

--- a/FragrantFlowers/Plants/Plant_RimedMallowConfig.cs
+++ b/FragrantFlowers/Plants/Plant_RimedMallowConfig.cs
@@ -16,14 +16,14 @@ namespace FragrantFlowers
 
         //===> BASE INFORMATION <=========================================
         public const string ID = "RimedMallowPlant";
-		public const string SEED_ID = "IceMallowSeed";
-		public const string PlantKanim = "plant_rimedmallow_kanim";
+        public const string SEED_ID = "IceMallowSeed";
+        public const string PlantKanim = "plant_rimedmallow_kanim";
         public const string SeedKanim = "seed_rimedmallow_kanim";
-		public const int WIDTH = 1;
-		public const int HEIGHT = 3;
+        public const int WIDTH = 1;
+        public const int HEIGHT = 3;
 
-		//===> DEFINE THE ANIMATION SETTINGS FOR A STANDARD CROP PLANT <=
-		private static StandardCropPlant.AnimSet animSet = new StandardCropPlant.AnimSet
+        //===> DEFINE THE ANIMATION SETTINGS FOR A STANDARD CROP PLANT <=
+        private static StandardCropPlant.AnimSet animSet = new StandardCropPlant.AnimSet
         {
             grow = "basic_grow",
             grow_pst = "basic_grow_pst",
@@ -37,117 +37,117 @@ namespace FragrantFlowers
         public const float TemperatureLethalLow = 118.15f;     //-155ºC: Plant will die (Lowest Temp)
         public const float TemperatureWarningLow = 183.15f;    // -60°C: Plant will stop growing (Lowest Temp)
         public const float TemperatureWarningHigh = 273.15f;   //   0°C: Plant will stop growing (Highest Temp)
-        public const float TemperatureLethalHigh = 283.15f;    //  10°C: Plant will die (Highest Temp)
+        public const float TemperatureLethalHigh = 298.15f;    //  25°C: Plant will die (Highest Temp)
 
-        public const float Fertilization = 0.0016666667f;         // Ice Fertilization Needed
+        public const float Fertilization = 1 / 100f;         // Ice Fertilization Needed
 
         public ComplexRecipe Recipe;
 
-		//===> DEFINE THE BASE TEMPLATE <=====================================================================
-		public GameObject CreatePrefab()
-		{
+        //===> DEFINE THE BASE TEMPLATE <=====================================================================
+        public GameObject CreatePrefab()
+        {
 
-			float mass = 2f;
-			EffectorValues tier = DECOR.BONUS.TIER1;
-			GameObject gameObject = EntityTemplates.CreatePlacedEntity(
-				ID, 
-				STRINGS.PLANTS.RIMEDMALLOW.NAME,
-				STRINGS.PLANTS.RIMEDMALLOW.DESC, 
-				mass, 
-				Assets.GetAnim(PlantKanim), 
-				"idle_empty", 
-				Grid.SceneLayer.BuildingFront,
-				WIDTH,
-				HEIGHT, 
-				tier, 
-				default(EffectorValues), 
-				SimHashes.Creature, 
-				new List<Tag> { GameTags.Hanging },
-				253.15f
-				);
+            float mass = 2f;
+            EffectorValues tier = DECOR.BONUS.TIER1;
+            GameObject gameObject = EntityTemplates.CreatePlacedEntity(
+                ID,
+                STRINGS.PLANTS.RIMEDMALLOW.NAME,
+                STRINGS.PLANTS.RIMEDMALLOW.DESC,
+                mass,
+                Assets.GetAnim(PlantKanim),
+                "idle_empty",
+                Grid.SceneLayer.BuildingFront,
+                WIDTH,
+                HEIGHT,
+                tier,
+                default(EffectorValues),
+                SimHashes.Creature,
+                new List<Tag> { GameTags.Hanging },
+                253.15f
+                );
 
-			EntityTemplates.MakeHangingOffsets(gameObject, WIDTH, HEIGHT);
-			EntityTemplates.ExtendEntityToBasicPlant(
-				gameObject,
-				TemperatureLethalLow,
-				TemperatureWarningLow,
-				TemperatureWarningHigh,
-				TemperatureLethalHigh,
-				null, 
-				true, 
-				0f, 
-				0.15f,
-				Crop_CottonBollConfig.ID, 
-				true, 
-				true,
-				true, 
-				true,
-				2400f,
-				0f, 
-				9800f, 
-				"RimedMallowOriginal",
-				"Rimed Mallow Original"
-				);
+            EntityTemplates.MakeHangingOffsets(gameObject, WIDTH, HEIGHT);
+            EntityTemplates.ExtendEntityToBasicPlant(
+                gameObject,
+                TemperatureLethalLow,
+                TemperatureWarningLow,
+                TemperatureWarningHigh,
+                TemperatureLethalHigh,
+                null,
+                true,
+                0f,
+                0.15f,
+                Crop_CottonBollConfig.ID,
+                true,
+                true,
+                true,
+                true,
+                2400f,
+                0f,
+                9800f,
+                "RimedMallowOriginal",
+                "Rimed Mallow Original"
+                );
 
-			EntityTemplates.ExtendPlantToFertilizable(gameObject, new PlantElementAbsorber.ConsumeInfo[]
-			{
-				new PlantElementAbsorber.ConsumeInfo
-				{
-					tag = SimHashes.Ice.CreateTag(),
-					massConsumptionRate = Fertilization
-				}
-			});
-			gameObject.GetComponent<UprootedMonitor>().monitorCells = new CellOffset[] {new CellOffset(0, 1)};
-			gameObject.AddOrGet<StandardCropPlant>();
-			
-			EntityTemplates.MakeHangingOffsets(EntityTemplates.CreateAndRegisterPreviewForPlant(
-				EntityTemplates.CreateAndRegisterSeedForPlant(
-					gameObject, 
-					SeedProducer.ProductionType.Harvest, 
-					SEED_ID,
-					STRINGS.SEEDS.RIMEDMALLOW.SEED_NAME,
-					STRINGS.SEEDS.RIMEDMALLOW.SEED_DESC, 
-					Assets.GetAnim(SeedKanim),
-					"object",
-					1, 
-					new List<Tag> { GameTags.CropSeed }, 
-					SingleEntityReceptacle.ReceptacleDirection.Bottom, 
-					default(Tag), 
-					4,
-					STRINGS.PLANTS.RIMEDMALLOW.DOMESTICATED_DESC, 
-					EntityTemplates.CollisionShape.CIRCLE,
-					0.3f, 
-					0.3f, 
-					null, 
-					"", 
-					false
-					),
-					"RimedMallowPlant_preview", 
-					Assets.GetAnim(PlantKanim), 
-					"place",
-					WIDTH, 
-					HEIGHT),
-				WIDTH,
-				HEIGHT);
+            EntityTemplates.ExtendPlantToFertilizable(gameObject, new PlantElementAbsorber.ConsumeInfo[]
+            {
+                new PlantElementAbsorber.ConsumeInfo
+                {
+                    tag = SimHashes.Ice.CreateTag(),
+                    massConsumptionRate = Fertilization
+                }
+            });
+            gameObject.GetComponent<UprootedMonitor>().monitorCells = new CellOffset[] { new CellOffset(0, 1) };
+            gameObject.AddOrGet<StandardCropPlant>();
 
-			//===> DISEASE OR GERMS THIS CROP RELEASES <===========================================================================
-			DiseaseDropper.Def def = gameObject.AddOrGetDef<DiseaseDropper.Def>();
-			def.diseaseIdx = Db.Get().Diseases.GetIndex(MallowScent.ID);
-			def.emitFrequency = 10f;
-			def.averageEmitPerSecond = 1000;
-			def.singleEmitQuantity = 100000;
-			gameObject.AddOrGet<DiseaseSourceVisualizer>().alwaysShowDisease = MallowScent.ID;
+            EntityTemplates.MakeHangingOffsets(EntityTemplates.CreateAndRegisterPreviewForPlant(
+                EntityTemplates.CreateAndRegisterSeedForPlant(
+                    gameObject,
+                    SeedProducer.ProductionType.Harvest,
+                    SEED_ID,
+                    STRINGS.SEEDS.RIMEDMALLOW.SEED_NAME,
+                    STRINGS.SEEDS.RIMEDMALLOW.SEED_DESC,
+                    Assets.GetAnim(SeedKanim),
+                    "object",
+                    1,
+                    new List<Tag> { GameTags.CropSeed },
+                    SingleEntityReceptacle.ReceptacleDirection.Bottom,
+                    default(Tag),
+                    4,
+                    STRINGS.PLANTS.RIMEDMALLOW.DOMESTICATED_DESC,
+                    EntityTemplates.CollisionShape.CIRCLE,
+                    0.3f,
+                    0.3f,
+                    null,
+                    "",
+                    false
+                    ),
+                    "RimedMallowPlant_preview",
+                    Assets.GetAnim(PlantKanim),
+                    "place",
+                    WIDTH,
+                    HEIGHT),
+                WIDTH,
+                HEIGHT);
 
-			return gameObject;
-		}
+            //===> DISEASE OR GERMS THIS CROP RELEASES <===========================================================================
+            DiseaseDropper.Def def = gameObject.AddOrGetDef<DiseaseDropper.Def>();
+            def.diseaseIdx = Db.Get().Diseases.GetIndex(MallowScent.ID);
+            def.emitFrequency = 10f;
+            def.averageEmitPerSecond = 1000;
+            def.singleEmitQuantity = 100000;
+            gameObject.AddOrGet<DiseaseSourceVisualizer>().alwaysShowDisease = MallowScent.ID;
 
-		public void OnPrefabInit(GameObject inst)
-		{
-		}
+            return gameObject;
+        }
 
-		public void OnSpawn(GameObject inst)
-		{
-		}
+        public void OnPrefabInit(GameObject inst)
+        {
+        }
 
-	}
+        public void OnSpawn(GameObject inst)
+        {
+        }
+
+    }
 }

--- a/FragrantFlowers/Plants/Plant_SpinosaConfig.cs
+++ b/FragrantFlowers/Plants/Plant_SpinosaConfig.cs
@@ -40,7 +40,7 @@ namespace FragrantFlowers
         public const float TemperatureLethalHigh = 398.15f;    // 125°C: Plant will die (Highest Temp)
 
         public const float Irrigation = 0.03f;             // Water Irrigation Needed
-        public const float Fertilization = 0.012f;         // Dirty Fertilization Needed
+        public const float Fertilization = 1 / 30.0f;         // Dirty Fertilization Needed
 
         public ComplexRecipe Recipe;
 
@@ -136,7 +136,7 @@ namespace FragrantFlowers
                 true, // Implies this Crop will grow old and eventualy yeilds a produce.
                 2400f, // Max age this Crop can grow, or the time it require for it to complete its growth.
                 0f, // Minium Radiation required by this Crop.
-                9800f, // Maxium value of Radiation this Crop can get before stop growing and dying.
+                TUNING.PLANTS.RADIATION_THRESHOLDS.TIER_5,  // Maxium value of Radiation this Crop can get before stop growing and dying.
                 "SpinozaOriginal", // Crop trait id.
                 "Spinoza Original"); // Crop trait name.
 
@@ -145,20 +145,21 @@ namespace FragrantFlowers
             {
             new PlantElementAbsorber.ConsumeInfo
             {
-                tag = SimHashes.Dirt.CreateTag(),
+                tag = SimHashes.Phosphorite.CreateTag(),
                 massConsumptionRate = Fertilization
             }
             });
 
             //===> LIQUID IRRIGATION THIS CROP REQUIRES <===========================================================================
-            EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
-            {
-            new PlantElementAbsorber.ConsumeInfo
-            {
-                tag = SimHashes.Water.CreateTag(),
-                massConsumptionRate = Irrigation
-            }
-            });
+            //EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
+            //{
+            //new PlantElementAbsorber.ConsumeInfo
+            //{
+            //    tag = SimHashes.Water.CreateTag(),
+            //    massConsumptionRate = Irrigation
+            //}
+            //});
+
             gameObject.AddOrGet<StandardCropPlant>();
             gameObject.AddOrGet<LoopingSounds>();
 

--- a/FragrantFlowers/Plants/Plant_SuperDuskLavenderConfig.cs
+++ b/FragrantFlowers/Plants/Plant_SuperDuskLavenderConfig.cs
@@ -29,14 +29,15 @@ namespace FragrantFlowers
 
         //===> TEMPERATURE SETTINGS <=====================================
         public const float DefaultTemperature = 299.15f;       //  26°C: Normal Temperature
-        public const float TemperatureLethalLow = 258.15f;     // -15ºC: Plant will die (Lowest Temp)
+        public const float TemperatureLethalLow = 243.15f;     // -30ºC: Plant will die (Lowest Temp)
         public const float TemperatureWarningLow = 288.15f;    //  15°C: Plant will stop growing (Lowest Temp)
         public const float TemperatureWarningHigh = 313.15f;   //  40°C: Plant will stop growing (Highest Temp)
         public const float TemperatureLethalHigh = 333.15f;    //  60°C: Plant will die (Highest Temp)
         public const int WIDTH = 1;
         public const int HEIGHT = 2;
 
-        public const float Fertilization = 0.014f;         // Phosphorite Fertilization Needed
+        public const float Irrigation = Plant_DuskLavenderConfig.Irrigation;              // Water Irrigation Needed
+        public const float Fertilization = Plant_DuskLavenderConfig.Fertilization;         // Phosphorite Fertilization Needed
 
         public ComplexRecipe Recipe;
 
@@ -105,7 +106,7 @@ namespace FragrantFlowers
                 true, // Implies this Crop will grow old and eventualy yeilds a produce.
                 2400f, // Max age this Crop can grow, or the time it require for it to complete its growth.
                 0f, // Minium Radiation required by this Crop.
-                9800f, // Maxium value of Radiation this Crop can get before stop growing and dying.
+                TUNING.PLANTS.RADIATION_THRESHOLDS.TIER_5,  // Maxium value of Radiation this Crop can get before stop growing and dying.
                 "SuperLavenderOriginal", // Crop trait id.
                 "Fruiting Lavender Original"); // Crop trait name.
 
@@ -114,19 +115,23 @@ namespace FragrantFlowers
             {
             new PlantElementAbsorber.ConsumeInfo
             {
-                tag = SimHashes.Phosphorite.CreateTag(),
+                tag = SimHashes.Dirt.CreateTag(),
                 massConsumptionRate = Fertilization
             }
             });
-
+            //===> LIQUID IRRIGATION THIS CROP REQUIRES <===========================================================================
+            EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
+            {
+            new PlantElementAbsorber.ConsumeInfo
+            {
+                tag = SimHashes.Water.CreateTag(),
+                massConsumptionRate = Irrigation
+            }
+            });
             gameObject.AddOrGet<StandardCropPlant>();
             gameObject.AddOrGet<LoopingSounds>();
             gameObject.AddOrGet<BlightVulnerable>();
-
-            //===> DISEASE OR GERMS THIS CROP RELEASES <===========================================================================
-            DiseaseDropper.Def def = gameObject.AddOrGetDef<DiseaseDropper.Def>();
-            def.diseaseIdx = Db.Get().Diseases.GetIndex(Db.Get().Diseases.PollenGerms.id);
-            def.singleEmitQuantity = 1000000;
+            gameObject.AddOrGet<IlluminationVulnerable>().SetPrefersDarkness(true);
 
             return gameObject;
         }

--- a/FragrantFlowers/Plants/Plant_SuperSpinosaConfig.cs
+++ b/FragrantFlowers/Plants/Plant_SuperSpinosaConfig.cs
@@ -36,8 +36,8 @@ namespace FragrantFlowers
         public const float TemperatureWarningHigh = 303.15f;   //  30°C: Plant will stop growing (Highest Temp)
         public const float TemperatureLethalHigh = 398.15f;    // 125°C: Plant will die (Highest Temp)
 
-        public const float Irrigation = 0.03f;             // Water Irrigation Needed
-        public const float Fertilization = 0.012f;         // Dirty Fertilization Needed
+        public const float Irrigation = Plant_SpinosaConfig.Irrigation;             // Water Irrigation Needed
+        public const float Fertilization = Plant_SpinosaConfig.Fertilization;        // Dirty Fertilization Needed
 
         public ComplexRecipe Recipe;
 
@@ -107,7 +107,7 @@ namespace FragrantFlowers
                 true, // Implies this Crop will grow old and eventualy yeilds a produce.
                 2400f, // Max age this Crop can grow, or the time it require for it to complete its growth.
                 0f, // Minium Radiation required by this Crop.
-                9800f, // Maxium value of Radiation this Crop can get before stop growing and dying.
+                TUNING.PLANTS.RADIATION_THRESHOLDS.TIER_5,  // Maxium value of Radiation this Crop can get before stop growing and dying.
                 "SuperSpinosaOriginal", // Crop trait id.
                 "Fruiting Spinosa Trait"); // Crop trait name.
 
@@ -116,20 +116,20 @@ namespace FragrantFlowers
             {
             new PlantElementAbsorber.ConsumeInfo
             {
-                tag = SimHashes.Dirt.CreateTag(),
+                tag = SimHashes.Phosphorite.CreateTag(),
                 massConsumptionRate = Fertilization
             }
             });
 
             //===> LIQUID IRRIGATION THIS CROP REQUIRES <===========================================================================
-            EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
-            {
-            new PlantElementAbsorber.ConsumeInfo
-            {
-                tag = SimHashes.Water.CreateTag(),
-                massConsumptionRate = Irrigation
-            }
-            });
+            //EntityTemplates.ExtendPlantToIrrigated(gameObject, new PlantElementAbsorber.ConsumeInfo[]
+            //{
+            //new PlantElementAbsorber.ConsumeInfo
+            //{
+            //    tag = SimHashes.Water.CreateTag(),
+            //    massConsumptionRate = Irrigation
+            //}
+            //});
             gameObject.AddOrGet<StandardCropPlant>();
             gameObject.AddOrGet<LoopingSounds>();
 


### PR DESCRIPTION
Hi! It's experimental rebalance branch. It mostly changes Spinosa and Lavender. I may be wrong about the role you gave to the plants, but since they can be food plants, I did some math. And it's much less profitable than in-game plants. If it's intened so, then ok. But I can't pass by fact that growth requirements for Spinosa are much higher than for Lavender. Spinosa needs light and consumes a lot of dirt and water, quite valuable resourses. Lavender consumes phosphorite and increases reproduction rate of the critters.  It emits germs even in fruiting form. In comparison to Spinosa, Lavender is literally OP.