### PR TITLE
FragrantFlowers - Vaporizer fixes

### DIFF
--- a/FragrantFlowers/AromaCans/FloralAromaCanConfig.cs
+++ b/FragrantFlowers/AromaCans/FloralAromaCanConfig.cs
@@ -42,7 +42,7 @@ namespace FragrantFlowers
             AromaticsFabricator.RegisterAromaticsRecipe(new ComplexRecipe.RecipeElement[1] { new ComplexRecipe.RecipeElement(ID, 1f) }, Db.Get().Diseases.PollenGerms.Id, "PollenGerms recipe");
 
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.AROMACANS.FLORAL.NAME, STRINGS.AROMACANS.FLORAL.DESC, 1f, true, Assets.GetAnim("aromatic_floralcent_kanim"), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
-            looseEntity.AddTag(GameTags.IndustrialIngredient);
+            looseEntity.AddTag(GameTags.IndustrialProduct);
             return looseEntity;
         }
     }

--- a/FragrantFlowers/AromaCans/LavenderAromaCanConfig.cs
+++ b/FragrantFlowers/AromaCans/LavenderAromaCanConfig.cs
@@ -42,7 +42,7 @@ namespace FragrantFlowers
             AromaticsFabricator.RegisterAromaticsRecipe(new ComplexRecipe.RecipeElement[1] { new ComplexRecipe.RecipeElement(ID, 1f) }, LavenderScent.ID, "LavenderScent recipe");
 
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.AROMACANS.LAVENDER.NAME, STRINGS.AROMACANS.LAVENDER.DESC, 1f, true, Assets.GetAnim("aromatic_lavenderscent_kanim"), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
-            looseEntity.AddTag(GameTags.IndustrialIngredient);
+            looseEntity.AddTag(GameTags.IndustrialProduct);
             return looseEntity;
         }
     }

--- a/FragrantFlowers/AromaCans/MallowAromaCanConfig.cs
+++ b/FragrantFlowers/AromaCans/MallowAromaCanConfig.cs
@@ -42,7 +42,7 @@ namespace FragrantFlowers
             AromaticsFabricator.RegisterAromaticsRecipe(new ComplexRecipe.RecipeElement[1] { new ComplexRecipe.RecipeElement(ID, 1f) }, MallowScent.ID, "MallowScent recipe");
 
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.AROMACANS.MALLOW.NAME, STRINGS.AROMACANS.MALLOW.DESC, 1f, true, Assets.GetAnim("aromatic_mallowscent_kanim"), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
-            looseEntity.AddTag(GameTags.IndustrialIngredient);
+            looseEntity.AddTag(GameTags.IndustrialProduct);
             return looseEntity;
         }
     }

--- a/FragrantFlowers/AromaCans/RoseAromaCanConfig.cs
+++ b/FragrantFlowers/AromaCans/RoseAromaCanConfig.cs
@@ -42,7 +42,7 @@ namespace FragrantFlowers
             AromaticsFabricator.RegisterAromaticsRecipe(new ComplexRecipe.RecipeElement[1] { new ComplexRecipe.RecipeElement(ID, 1f) }, RoseScent.ID, "RoseScent recipe");
 
             GameObject looseEntity = EntityTemplates.CreateLooseEntity(ID, STRINGS.AROMACANS.ROSE.NAME, STRINGS.AROMACANS.ROSE.DESC, 1f, true, Assets.GetAnim("aromatic_rosescent_kanim"), "object", Grid.SceneLayer.Front, EntityTemplates.CollisionShape.RECTANGLE, 0.8f, 0.4f, true);
-            looseEntity.AddTag(GameTags.IndustrialIngredient);
+            looseEntity.AddTag(GameTags.IndustrialProduct);
             return looseEntity;
         }
     }

--- a/FragrantFlowers/Buildings/VaporizerConfig.cs
+++ b/FragrantFlowers/Buildings/VaporizerConfig.cs
@@ -27,12 +27,13 @@ namespace FragrantFlowers
 
         public override void DoPostConfigureComplete(GameObject go)
         {
-            go.AddOrGet<Operational>();
             go.AddOrGet<LogicOperationalController>();
-            go.AddOrGet<ComplexFabricatorWorkable>();
             go.AddOrGetDef<VaporizerController.Def>();
+            go.AddOrGet<DiseaseSourceVisualizer>();
+            Prioritizable.AddRef(go);
             AromaticsFabricator af = go.AddOrGet<AromaticsFabricator>();
             BuildingTemplates.CreateComplexFabricatorStorage(go, af);
+            af.duplicantOperated = false;
         }
     }
 }


### PR DESCRIPTION
Hi! Here is some fixes for vaporizer.
1) added priopity support
2) fixed a bug that caused game to freeze and crash when dublcicants tried to do some work at vaporiver 
3) fixed a bug where DiseaseSourceVisualizer didnt show up after loading save
4) fixed a bug where DiseaseSourceVisualizer didnt reappear after vaporiver was turned off due to a power cut or automation
