### PR TITLE
DiseasesExpanded - Radiation Sickness support

### DIFF
--- a/DiseasesExpanded/GermFlasks/TestSampleConfig.cs
+++ b/DiseasesExpanded/GermFlasks/TestSampleConfig.cs
@@ -89,6 +89,11 @@ namespace DiseasesExpanded
                     infectingGerms.Add(germId);
             }
 
+            RadiationMonitor.Instance smi = worker.GetSMI<RadiationMonitor.Instance>();
+
+            if (smi != null && smi.sm.isSick.Get(smi))
+                infectingGerms.Add(RadiationPoisoning.ID);
+
             if (infectingGerms.Count == 0)
                 return;
 

--- a/DiseasesExpanded/Patches/DiseasesExpanded_Patches_Medicine.cs
+++ b/DiseasesExpanded/Patches/DiseasesExpanded_Patches_Medicine.cs
@@ -47,6 +47,11 @@ namespace DiseasesExpanded
                         if (et.sickness_id == si.Sickness.id && !string.IsNullOrEmpty(et.germ_id))
                             return true;
 
+                RadiationMonitor.Instance smi = worker.GetSMI<RadiationMonitor.Instance>();
+
+                if (smi != null && smi.sm.isSick.Get(smi))
+                    return true;
+
                 return false;
             }
         }


### PR DESCRIPTION
Hi! Duplicants suffering from radiation sickness can now consume a test flask and create a radiation flask.