### PR TITLE
FragrantFlowers - Scent dictionary fix for Vaporizer

### DIFF
--- a/FragrantFlowers/Buildings/AromaticsFabricator.cs
+++ b/FragrantFlowers/Buildings/AromaticsFabricator.cs
@@ -13,7 +13,7 @@ namespace FragrantFlowers
 
         public static readonly Tag BasicCanIngridientTag = SimHashes.Ethanol.CreateTag();
         public static readonly float BasicCanIngridientMass = 100;
-        public static Dictionary<ComplexRecipe, string> RecipesScents = new Dictionary<ComplexRecipe, string>();
+        public static Dictionary<string, string> RecipesScents = new Dictionary<string, string>();
 
         public static void RegisterAromaticsRecipe(ComplexRecipe.RecipeElement[] ingredients, string germId, string Description)
         {
@@ -32,8 +32,8 @@ namespace FragrantFlowers
             };
 
             if (RecipesScents == null)
-                RecipesScents = new Dictionary<ComplexRecipe, string>();
-            RecipesScents.Add(recipe, germId);
+                RecipesScents = new Dictionary<string, string>();
+            RecipesScents.Add(recipe.id, germId);
         }
 
         public void SpawnGerms(GameObject go, string germId, float dt, int amountPerSecond = 5000)
@@ -55,8 +55,9 @@ namespace FragrantFlowers
 
         public string GetGermIdFromRecipe(ComplexRecipe recipe)
         {
-            if (recipe != null && RecipesScents.ContainsKey(recipe))
-                return RecipesScents[recipe];
+            if (recipe != null && RecipesScents.ContainsKey(recipe.id))
+                return RecipesScents[recipe.id];
+
             return string.Empty;
         }
 


### PR DESCRIPTION
Hi! Currently vaporizer doesn't work. It appears that the ComplexRecipe object from the ComplexFabricator now is now different from the object generated in RegisterAromaticsRecipe method.

I know I have already asked you, but I want to ask again. I would like to show you my rebalance of FragrantFlowers mod. You are very meticulous about your mods and I remember that it was make in collaboration with Ronivan. But I think there is still room for improvement. 

Happy New Year!