### PR TITLE
RoomsExpanded - Crashed Satellites count as Radiation Sources

### DIFF
--- a/RoomsExpanded/Patches/RoomsExpanded_Patches_NurseryGenetic.cs
+++ b/RoomsExpanded/Patches/RoomsExpanded_Patches_NurseryGenetic.cs
@@ -40,5 +40,38 @@ namespace RoomsExpanded
                 __result = roll < (1 + Settings.Instance.NurseryGenetic.Bonus) * chance;
             }
         }
+
+        [HarmonyPatch(typeof(PropSurfaceSatellite1Config))]
+        [HarmonyPatch("CreatePrefab")]
+        public static class PropSurfaceSatellite1Config_CreatePrefab_Patch
+        {
+            public static void Postfix(ref GameObject __result)
+            {
+                if (Settings.Instance.NurseryGenetic.IncludeRoom)
+                    __result.AddTag(GameTags.RoomProberBuilding);
+            }
+        }
+
+        [HarmonyPatch(typeof(PropSurfaceSatellite2Config))]
+        [HarmonyPatch("CreatePrefab")]
+        public static class PropSurfaceSatellite2Config_CreatePrefab_Patch
+        {
+            public static void Postfix(ref GameObject __result)
+            {
+                if (Settings.Instance.NurseryGenetic.IncludeRoom)
+                    __result.AddTag(GameTags.RoomProberBuilding);
+            }
+        }
+
+        [HarmonyPatch(typeof(PropSurfaceSatellite3Config))]
+        [HarmonyPatch("CreatePrefab")]
+        public static class PropSurfaceSatellite3Config_CreatePrefab_Patch
+        {
+            public static void Postfix(ref GameObject __result)
+            {
+                if (Settings.Instance.NurseryGenetic.IncludeRoom)
+                    __result.AddTag(GameTags.RoomProberBuilding);
+            }
+        }
     }
 }


### PR DESCRIPTION
Introduce some patches to add the `RoomProberBuilding` game tag to Crashed Satellites when the Genetic Nursery room is enabled, so that they count as Radiation Sources for the room constraint.