### PR TITLE
FragrantFlowers - More accessible ingredients for Rimed and Inspiring…

### DIFF
--- a/FragrantFlowers/Plants/Crop_CottonBollConfig.cs
+++ b/FragrantFlowers/Plants/Crop_CottonBollConfig.cs
@@ -99,7 +99,7 @@ namespace FragrantFlowers
                 SPICE_ID,
                 new Spice.Ingredient[2] {
                     new Spice.Ingredient() { IngredientSet = new Tag[1] { ID }, AmountKG = 0.1f },
-                    new Spice.Ingredient() { IngredientSet = new Tag[1] { SimHashes.Ice.CreateTag() }, AmountKG = 3f }
+                    new Spice.Ingredient() { IngredientSet = new Tag[1] { SimHashes.OxyRock.CreateTag() }, AmountKG = 3f }
                 },
                 MallowScent.colorValue,
                 Color.white,

--- a/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
+++ b/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
@@ -95,7 +95,7 @@ namespace FragrantFlowers
                 SPICE_ID,
                 new Spice.Ingredient[2] {
                     new Spice.Ingredient() { IngredientSet = new Tag[1] { ID }, AmountKG = 0.1f },
-                    new Spice.Ingredient() { IngredientSet = new Tag[1] { SimHashes.SandStone.CreateTag() }, AmountKG = 3f }
+                    new Spice.Ingredient() { IngredientSet = new Tag[1] { SimHashes.RefinedCarbon.CreateTag() }, AmountKG = 3f }
                 },
                 RoseScent.colorValue,
                 Color.white,


### PR DESCRIPTION
Hi! It looks like the devs decided to make Spice Grinder more appealing by lowering skill requirements. So I suggest doing the same with spices.
Sandstone is not found on every planetoid, and the only renewable source of it is rocket mining. I recommend replacing it with Refined Carbon. It can be made on any planetoid, and for me it's quite scientific)
The problem with ice is that it melts quickly inside the spice grinder. So I recommend replacing it with Oxylite. It sublimates just like slime but this can be prevented by atmospheric pressure. And what can be better for Athletics than an oxygen)