### PR TITLE
FragrantFlowers -Integration of cures recipes from the mod into exist…

### DIFF
--- a/FragrantFlowers/Patches/FragrantFlowers_Patches_Plants.cs
+++ b/FragrantFlowers/Patches/FragrantFlowers_Patches_Plants.cs
@@ -80,5 +80,32 @@ namespace FragrantFlowers
                 RegisterStrings.MakeIndustrialProductStrings(RoseAromaCanConfig.ID, STRINGS.AROMACANS.ROSE.NAME, STRINGS.AROMACANS.ROSE.DESC);
             }
         }
+
+        [HarmonyPatch(typeof(AntihistamineConfig), "CreatePrefab")]
+        public static class AntihistamineConfig_CreatePrefab_Patch
+        {
+            public static void Postfix()
+            {
+                AntihistamineConfig.recipes[0].ingredients[0].possibleMaterials =
+                    AntihistamineConfig.recipes[0].ingredients[0].possibleMaterials.Append(Crop_DuskbloomConfig.ID);
+                AntihistamineConfig.recipes[0].ingredients[0].possibleMaterialAmounts =
+                    AntihistamineConfig.recipes[0].ingredients[0].possibleMaterialAmounts.Append(1f);
+            }
+        }
+
+        [HarmonyPatch(typeof(IntermediateCureConfig), "CreatePrefab")]
+        public static class IntermediateCureConfig_CreatePrefab_Patch
+        {
+            public static void Postfix()
+            {
+                var ing = IntermediateCureConfig.recipe.ingredients[0];
+
+                if (ing.possibleMaterialAmounts != null)
+                    ing.possibleMaterialAmounts = ing.possibleMaterialAmounts.Append(1f);
+
+                ing.material = null;
+                ing.possibleMaterials = ing.possibleMaterials.Append(Crop_SpinosaRoseConfig.ID);
+            }
+        }
     }
 }

--- a/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
+++ b/FragrantFlowers/Plants/Crop_DuskbloomConfig.cs
@@ -58,7 +58,7 @@ namespace FragrantFlowers
             decorProvider.SetValues(DECOR.BONUS.TIER0);
             decorProvider.overrideName = STRINGS.CROPS.DUSKBLOOM.NAME;
 
-            DefineRecipe();
+            //DefineRecipe();
 
             return go;
         }

--- a/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
+++ b/FragrantFlowers/Plants/Crop_SpinosaRoseConfig.cs
@@ -57,7 +57,7 @@ namespace FragrantFlowers
             decorProvider.SetValues(DECOR.BONUS.TIER0);
             decorProvider.overrideName = STRINGS.CROPS.SPINOSAROSE.NAME;
 
-            DefineRecipe();
+            //DefineRecipe();
 
             return go;
         }


### PR DESCRIPTION
Hi! I propose that instead of creating new cure recipes, we integrate new ones into existing ones. This will make the experience of using the mod more seamless. Additionally, when using the Disease Expanded mod, for example, the Apothecary gets quite a few recipes. And duplicate recipes don't make it any easier.