### PR TITLE
FragrantFlowers -RimedMallow temperature range changed to -50 and -10

### DIFF
--- a/FragrantFlowers/Plants/Plant_RimedMallowConfig.cs
+++ b/FragrantFlowers/Plants/Plant_RimedMallowConfig.cs
@@ -36,8 +36,8 @@ namespace FragrantFlowers
         //===> TEMPERATURE SETTINGS <=====================================
         public const float DefaultTemperature = 253.15f;       // -20°C: Normal Temperature
         public const float TemperatureLethalLow = 118.15f;     //-155ºC: Plant will die (Lowest Temp)
-        public const float TemperatureWarningLow = 183.15f;    // -60°C: Plant will stop growing (Lowest Temp)
-        public const float TemperatureWarningHigh = 273.15f;   //   0°C: Plant will stop growing (Highest Temp)
+        public const float TemperatureWarningLow = 223.15f;    // -50°C: Plant will stop growing (Lowest Temp)
+        public const float TemperatureWarningHigh = 263.15f;   // -10°C: Plant will stop growing (Highest Temp)
         public const float TemperatureLethalHigh = 283.15f;    //  10°C: Plant will die (Highest Temp)
 
         public const float Fertilization = 0.0016666667f;         // Ice Fertilization Needed


### PR DESCRIPTION
Hi! I assume you're about to update the mod, so I'm bringing the topic up again. I checked, the Easygoing plant has temp range of -60 to 0 range.
I also forgot to ask about MallowScent. Yes, the plant is designed for cold environment. But does that mean that Mallow Scent Can for Vaporizer can only be used in cold conditions?